### PR TITLE
Typo in TB0GradX2

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,14 @@ If you want to export several parts of a Solidworks assembly you can do the foll
 
 Magnetic and electric fields (2D and 3D) can be included from text-based field maps.
 2D maps are assumed to be rotationally symmetric around the z axis. They can contain columns for r, z, Bx, By, Bz, Ex, Ey, Ez, and V exported from "[Vectorfields OPERA](http://www.operafea.com)" on a regular grid (each field column is optional).
+
 3D maps can contain generic columns for x, y, z, Bx, By, Bz on a rectilinear grid. Lines beginning with % or # will be skipped, columns may be delineated by space, comma, or tab.
 3D maps can also be exported from OPERA with columns x, y, z, Bx, By, Bz, V on a rectilinear grid (each field column is optional).
-Units for field maps are assumed to be in meters, Tesla, and Volts, but each can be scaled individually.
-You can also define a variety of analytically calculated fields. See default config file for more information.
+
+Units of field maps are assumed to be in meters, Tesla, and Volts, but each can be scaled individually.
+
+You can also define a variety of analytically calculated fields. See default config file and test/analyticalFieldTest/config.in for more information.
+
 Every field type can be scaled with a user-defined time-dependent formula to simulate oscillating fields or magnets that are ramped up and down.
 
 ### Particle sources

--- a/in/config.in
+++ b/in/config.in
@@ -155,10 +155,7 @@ polarization 0	# initial polarization is randomly chosen, weighted by this varia
 #
 # Analytically calculated fields:
 # Conductor: simulate a current flowing from one point to another along an arbitrary straight line
-# EDMStaticEField: simulate a uniform electric field along an arbitrary direction
-# EDMStaticB0GradZField: simulate a magnetic field along the z-axis with a uniform gradient
-# ExponentialFieldX: simulate magnetic field B = (a1 exp(-a2 x + a3) + c1, 1/2 y a1 a2 exp(-a2 x + a3) + c2, 1/2 z a1 a2 exp(-a2 x + a3) + c2) in a box
-# LinearFieldZ: simulate magnetic field along z and linear in x: B = (0, 0, a1*x + a2) in a box
+# For more information on the other analytically calculated fields, see test/analyticalFieldTest/config.in
 # All coordinates are defined in meters, currents in ampere, fields in Tesla
 #
 # Each line is preceded by a unique identifier. Entries with duplicate identifiers will overwrite each other
@@ -172,7 +169,7 @@ polarization 0	# initial polarization is randomly chosen, weighted by this varia
 #3 OPERA3D	3Dtable.tab	1		1		0		1
 #4 COMSOL	comsol.txt	1		1		0		1
 
-#FiniteWire		I		x1		y1		z1		x2		y2		z2		scale
+#Conductor		I		x1		y1		z1		x2		y2		z2		scale
 5 Conductor		12500	0		0		-1		0		0		2		1
 
 ### See PENTrack/test/analyticalFieldTest/ or doxygen documentation for more info on analytical field parameters ###
@@ -200,6 +197,8 @@ polarization 0	# initial polarization is randomly chosen, weighted by this varia
 #HarmonicExpandedBField     edmB0xoff   edmB0yoff   edmB0zoff   BoundaryWidth   xmax 	xmin 	ymax 	ymin 	zmax 	zmin    scale   axis_x  axis_y  axis_z  angle   G(0,-1) G(0,0)  G(0,1)  G(1,-2) G(1,-1) G(1,0)  G(1,1)  G(1,2)  G(2,-3) G(2,-2) G(2,-1) G(2,0)  G(2,1)  G(2,2)  G(2,3)  G(3,-4) G(3,-3) G(3,-2) G(3,-1) G(3,0)  G(3,1)  G(3,2)  G(3,3)  G(3,4)
 #13 HarmonicExpandedBField 	0	        0        0	        0.01        1    -1  	  1 	    -1	    1	    -1	    1       1       1       1       1.9     0       0       0       0       0       30      0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
 
+#EDMStaticEField    Ex  Ey  Ez  scale
+#14 EDMStaticEField 0   0   1e6 1
 
 ######### default values for particle-specific settings ############
 [PARTICLES]

--- a/src/analyticFields.cpp
+++ b/src/analyticFields.cpp
@@ -170,7 +170,7 @@ void TB0GradX2::BField(const double x, const double y, const double z, const dou
 	double Bscale = BScaling(t);	// Time dependent scaling
 
 	if (withinBounds(x, y, z) && (Bscale != 0)) {
-		B[0] = Bscale * ( -a3/6*x*x*x - a2/4*x*x -a3/2*x ); //Bx contribution
+		B[0] = Bscale * ( -a1/6*x*x*x - a2/4*x*x -a3/2*x ); //Bx contribution
 		B[1] = Bscale * ( -( a1*x*x + a2*x + a3 ) / 2 * y ); //By contribution
 		B[2] = Bscale * ((a1*x*x + a2*x + a3) * z + z0); //Bz contribution
 		if (dBidxj != NULL){

--- a/test/analyticalFieldTest/config.in
+++ b/test/analyticalFieldTest/config.in
@@ -32,6 +32,10 @@ BCutPlane -1 0.5 0  -1 0.5 0  1 0.5 0  1 150
 ## LinearFieldZ a1      a2     xmax  xmin  ymax  ymin  zmax  zmin scale
 #1 LinearFieldZ  2E-6   1E-6   0     -1     1     -1     1     -1   1
 
+# EDMStaticB0GradZField defines a z-oriented field of strength edmB0z0 with a small gradient edmB0z0dz along z, leading to small x and y components.
+# The origin and orientation of the z-axis can be adjusted with the edmB0[xyz]off parameters and a polar and azimuthal angle.
+# The field is only evaluated within x/y/z min/max boundaries. If a BoundaryWidth is defined, the field will be brought smoothly to zero outside these boundaries.
+
 ### EDMStaticB0GradZField   edmB0xoff edmB0yoff edmB0zoff pol_ang azm_ang edmB0z0 edmdB0z0dz BoundaryWidth xmax    xmin    ymax    ymin    zmax    zmin scale
 #1 EDMStaticB0GradZField     0         0          0       0       0       1E-6    0          0             3       0      1       -1      1       -1      1
 
@@ -70,5 +74,18 @@ BCutPlane -1 0.5 0  -1 0.5 0  1 0.5 0  1 150
 
 ## B0_XY    a1    z0       xmax  xmin  ymax  ymin  zmax  zmin scale
 1 B0_XY   1E-7  1E-6        1     -1     1     -1     1  -1   1
+
+# HarmonicExpandedBField defines a field composed of Legendre polynomials up to third order with coefficients G(l,m), see https://arxiv.org/abs/1811.06085.
+# The origin can be adjusted with the edmB0[xyz]off parameters. The orientation can be rotated by a given angle around an axis.
+# The field is only evaluated within x/y/z min/max boundaries. If a BoundaryWidth is defined, the field will be brought smoothly to zero outside these boundaries.
+
+#HarmonicExpandedBField     edmB0xoff   edmB0yoff   edmB0zoff   BoundaryWidth   xmax 	xmin 	ymax 	ymin 	zmax 	zmin    scale   axis_x  axis_y  axis_z  angle   G(0,-1) G(0,0)  G(0,1)  G(1,-2) G(1,-1) G(1,0)  G(1,1)  G(1,2)  G(2,-3) G(2,-2) G(2,-1) G(2,0)  G(2,1)  G(2,2)  G(2,3)  G(3,-4) G(3,-3) G(3,-2) G(3,-1) G(3,0)  G(3,1)  G(3,2)  G(3,3)  G(3,4)
+#1 HarmonicExpandedBField 	0	        0        0	        0.01        1    -1  	  1 	    -1	    1	    -1	    1       1       1       1       1.9     0       0       0       0       0       30      0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
+
+# EDMStaticEField defines an homogeneous electric field, simply set all three components of the electric-field vector.
+
+#EDMStaticEField   Ex  Ey  Ez  scale
+#1 EDMStaticEField 0   0   1e6 1
+
 
 [PARTICLES]


### PR DESCRIPTION
I believe there is a typo in one of the coefficients of Bx in TB0GradX2. Could you double check if my fix is correct?